### PR TITLE
feat: migrate spring cloud open feign -> rabbitMQ

### DIFF
--- a/accountService/src/main/java/com/fsocial/accountservice/config/RabbitMQConfig.java
+++ b/accountService/src/main/java/com/fsocial/accountservice/config/RabbitMQConfig.java
@@ -1,0 +1,4 @@
+package com.fsocial.accountservice.config;
+
+public class RabbitMQConfig {
+}

--- a/profileService/src/main/java/com/fsocial/profileservice/comsumer/ProfileConsumer.java
+++ b/profileService/src/main/java/com/fsocial/profileservice/comsumer/ProfileConsumer.java
@@ -1,0 +1,4 @@
+package com.fsocial.profileservice.comsumer;
+
+public class ProfileConsumer {
+}

--- a/profileService/src/main/java/com/fsocial/profileservice/config/RabbitMQConfig.java
+++ b/profileService/src/main/java/com/fsocial/profileservice/config/RabbitMQConfig.java
@@ -1,0 +1,38 @@
+package com.fsocial.accountservice.config;
+
+import com.fsocial.accountservice.enums.exchange.Exchange;
+import com.fsocial.accountservice.enums.queue.ProfileQueue;
+import com.fsocial.accountservice.enums.routingkey.ProfileRoutingKey;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    @Bean
+    public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public Queue profileCreateQueue() {
+        return new Queue(ProfileQueue.PROFILE_CREATE.getQueue(), true);
+    }
+
+    @Bean
+    public DirectExchange profileExchange() {
+        return new DirectExchange(Exchange.PROFILE.getExchange());
+    }
+
+    // Binding profile create
+    @Bean
+    public Binding profileCreateBinding(Queue profileCreateQueue, DirectExchange profileExchange) {
+        return BindingBuilder.bind(profileCreateQueue).to(profileExchange).with(ProfileRoutingKey.CREATE.getRoutingKey());
+    }
+
+}

--- a/profileService/src/main/java/com/fsocial/profileservice/enums/exchange/Exchange.java
+++ b/profileService/src/main/java/com/fsocial/profileservice/enums/exchange/Exchange.java
@@ -1,0 +1,13 @@
+package com.fsocial.accountservice.enums.exchange;
+
+import lombok.Getter;
+
+@Getter
+public enum Exchange {
+    PROFILE("profile");
+    private final  String exchange;
+
+    Exchange(String exchange){
+        this.exchange = exchange;
+    }
+}

--- a/profileService/src/main/java/com/fsocial/profileservice/enums/queue/ProfileQueue.java
+++ b/profileService/src/main/java/com/fsocial/profileservice/enums/queue/ProfileQueue.java
@@ -1,0 +1,14 @@
+package com.fsocial.accountservice.enums.queue;
+
+import lombok.Getter;
+
+@Getter
+public enum ProfileQueue {
+    PROFILE_CREATE("profile.create");
+
+    private final String queue;
+
+    ProfileQueue(String queue) {
+        this.queue = queue;
+    }
+}

--- a/profileService/src/main/java/com/fsocial/profileservice/enums/routingkey/ProfileRoutingKey.java
+++ b/profileService/src/main/java/com/fsocial/profileservice/enums/routingkey/ProfileRoutingKey.java
@@ -1,0 +1,15 @@
+package com.fsocial.accountservice.enums.routingkey;
+
+import lombok.Getter;
+
+@Getter
+public enum ProfileRoutingKey {
+    CREATE("create"),
+    UPDATE("update"),
+    DELETE("delete");
+
+    private final String routingKey;
+    ProfileRoutingKey(String routingKey) {
+        this.routingKey = routingKey;
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce RabbitMQ exchange/queue/binding and JSON message converter for profile service; add consumer stub and a placeholder config in account service.
> 
> - **Messaging (profileService)**
>   - **RabbitMQ config**: Define `DirectExchange` (`Exchange.PROFILE`), durable queue `ProfileQueue.PROFILE_CREATE`, and binding via `ProfileRoutingKey.CREATE` in `config/RabbitMQConfig`.
>   - **Message conversion**: Add `Jackson2JsonMessageConverter` bean.
>   - **Enums**: Add `enums/exchange/Exchange`, `enums/queue/ProfileQueue`, and `enums/routingkey/ProfileRoutingKey`.
>   - **Consumer**: Add stub `comsumer/ProfileConsumer`.
> - **Messaging (accountService)**
>   - Add placeholder `config/RabbitMQConfig` class.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 807de0c36ae4f9ebb15ea6898aafb1cdc28f7628. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->